### PR TITLE
Create model for authentication

### DIFF
--- a/priv/repo/migrations/20180207183550_create_user.exs
+++ b/priv/repo/migrations/20180207183550_create_user.exs
@@ -1,0 +1,14 @@
+defmodule Babble.Repo.Migrations.CreateUser do
+  use Ecto.Migration
+
+  def change do
+    create table(:users) do
+      add :email, :string
+      add :encrypt_pass, :string
+
+      timestamps()
+    end
+
+    create unique_index(:users, [:email])
+  end
+end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -1,0 +1,18 @@
+defmodule Babble.UserTest do
+  use Babble.ModelCase
+
+  alias Babble.User
+
+  @valid_attrs %{email: "some email", encrypt_pass: "some encrypt_pass"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = User.changeset(%User{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = User.changeset(%User{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -1,0 +1,21 @@
+defmodule Babble.User do
+  use Babble.Web, :model
+
+  schema "users" do
+    field :email, :string
+    field :encrypt_pass, :string
+    field :password, :string, virtual: true
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:email, :password])
+    |> validate_required([:email, :password])
+    |> unique_constraint(:email)
+  end
+end


### PR DESCRIPTION
- To create migrations, used
`mix phoenix.gen.model User users email:unique encrypt_pass:string`

- Checked migration in priv/repo/migrations

- In models/user file, added line to schema `users`:
`field :password, :string, virtual: true`,
and under `changeset` changed `encrypt_pass` to `password`

- Ran in terminal `mix ecto.migrate`